### PR TITLE
Add fan speed and swap C and F

### DIFF
--- a/nvidia_exporter.go
+++ b/nvidia_exporter.go
@@ -29,6 +29,10 @@ var (
 			help:   "Power Usage of an NVIDIA GPU in Watts",
 			labels: []string{"device_id", "device_uuid", "device_name"},
 		},
+		"fan_speed": &VecInfo{
+                        help:   "Device Fan Speed in Percent of Maximum",
+                        labels: []string{"device_id", "device_uuid", "device_name"},
+                },
 		"gpu_percent": &VecInfo{
 			help:   "Percent of GPU Utilized",
 			labels: []string{"device_id", "device_uuid", "device_name"},
@@ -113,6 +117,7 @@ func (e *Exporter) GetTelemetryFromNVML() {
 	var (
 		gpuMem                    *NVMLMemory
 		powerUsage                int
+		fanSpeed		  int
 		gpuPercent, memoryPercent int
 		err                       error
 		tempF, tempC              int
@@ -136,6 +141,11 @@ func (e *Exporter) GetTelemetryFromNVML() {
 			goto ErrorFetching
 		}
 		e.gauges["power_watts"].WithLabelValues(id, device.DeviceUUID, device.DeviceName).Set(float64(powerUsage))
+
+		if fanSpeed, err = device.GetFanSpeed(); err != nil {
+                        goto ErrorFetching
+                }
+		e.gauges["fan_speed"].WithLabelValues(id, device.DeviceUUID, device.DeviceName).Set(float64(fanSpeed))
 
 		if gpuMem, err = device.GetMemoryInfo(); err != nil {
 			goto ErrorFetching

--- a/nvidia_exporter.go
+++ b/nvidia_exporter.go
@@ -131,7 +131,7 @@ func (e *Exporter) GetTelemetryFromNVML() {
 		e.gauges["gpu_percent"].WithLabelValues(id, device.DeviceUUID, device.DeviceName).Set(float64(gpuPercent))
 		e.gauges["memory_percent"].WithLabelValues(id, device.DeviceUUID, device.DeviceName).Set(float64(memoryPercent))
 
-		if tempF, tempC, err = device.GetTemperature(); err != nil {
+		if tempC, tempF, err = device.GetTemperature(); err != nil {
 			goto ErrorFetching
 		}
 		e.gauges["temperature_celsius"].WithLabelValues(id, device.DeviceUUID, device.DeviceName).Set(float64(tempC))

--- a/nvml.go
+++ b/nvml.go
@@ -120,6 +120,15 @@ func (s *Device) GetPowerUsage() (int, error) {
 	return usage / 1000, nil
 }
 
+// GetFanSpeed returns the fan speed in percent
+func (s *Device) GetFanSpeed() (int, error) {
+        speed, err := s.callGetIntFunc(C.getNvmlIntProperty(C.nvmlDeviceGetFanSpeed))
+        if err != nil {
+                return 0, err
+        }
+        return speed, nil
+}
+
 // GetTemperature returns the Device's temperature in Farenheit and celsius
 func (s *Device) GetTemperature() (int, int, error) {
 	var tempc C.uint


### PR DESCRIPTION
Simple patch to add device fan speed as a percentage of the maximum.

Also fixed a transpose in the reporting of Celsius and Fahrenheit since nvidia-smi reports temp in Celsius.